### PR TITLE
Implement minimal CLI CRM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+crm.db

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
-# CRM
-CRM
+# CRM CLI
+
+Este proyecto proporciona una peque\u00f1a aplicaci\u00f3n en l\u00ednea de comandos para gestionar
+clientes, dominios y tickets. Utiliza SQLite y est\u00e1 implementado s\u00f3lo con la
+biblioteca est\u00e1ndar de Python.
+
+## Instalaci\u00f3n
+
+No se necesitan dependencias externas. Para inicializar la base de datos ejecute:
+
+```bash
+python -m crm_app init
+```
+
+## Comandos principales
+
+- `add_client` \u2013 A\u00f1ade un cliente.
+- `list_clients` \u2013 Muestra los clientes registrados.
+- `add_domain` \u2013 A\u00f1ade un dominio a un cliente.
+- `add_ticket` \u2013 Registra un ticket asociado a un cliente.
+- `list_tickets` \u2013 Lista los tickets que no est\u00e1n finalizados.
+- `search` \u2013 Permite buscar clientes por nombre, empresa o dominio.
+
+Ejemplo de uso para crear un cliente:
+
+```bash
+python -m crm_app add_client --full_name "Juan Perez" --company_name "Mi Empresa" \
+  --emails juan@ejemplo.com --phones 123456789 --origin App --status Activo
+```
+
+Para ver los tickets abiertos:
+
+```bash
+python -m crm_app list_tickets
+```

--- a/crm_app/__init__.py
+++ b/crm_app/__init__.py
@@ -1,0 +1,6 @@
+"""Simple CRM application."""
+
+from .cli import main
+from . import database
+
+__all__ = ['main', 'database']

--- a/crm_app/__main__.py
+++ b/crm_app/__main__.py
@@ -1,0 +1,4 @@
+from .cli import main
+
+if __name__ == '__main__':
+    main()

--- a/crm_app/cli.py
+++ b/crm_app/cli.py
@@ -1,0 +1,155 @@
+import argparse
+import json
+from datetime import datetime
+from . import database as db
+
+
+def cmd_init(args):
+    db.init_db()
+    print("Database initialized")
+
+
+def cmd_add_client(args):
+    emails = args.emails.split(',') if args.emails else []
+    phones = args.phones.split(',') if args.phones else []
+    db.add_client(
+        origin=args.origin,
+        status=args.status,
+        reason_baja=args.reason_baja,
+        full_name=args.full_name,
+        dni_nie=args.dni_nie,
+        emails=emails,
+        province=args.province,
+        city=args.city,
+        address=args.address,
+        postal_code=args.postal_code,
+        legal_form=args.legal_form,
+        company_name=args.company_name,
+        commercial_name=args.commercial_name,
+        nif=args.nif,
+        phones=phones
+    )
+    print("Client added")
+
+
+def cmd_list_clients(args):
+    rows = db.list_clients()
+    for r in rows:
+        print(r)
+
+
+def cmd_search(args):
+    rows = db.search_clients(name=args.name, company=args.company, domain=args.domain)
+    for r in rows:
+        print(r)
+
+
+def cmd_add_domain(args):
+    db.add_domain(
+        client_id=args.client_id,
+        domain_name=args.domain_name,
+        date_added=args.date_added or datetime.now().strftime('%Y-%m-%d'),
+        type=args.type,
+        migration_status=args.migration_status,
+        migration_date=args.migration_date,
+        server_user=args.server_user,
+        server_password=args.server_password,
+        domain_server=args.domain_server,
+        notes=args.notes
+    )
+    print("Domain added")
+
+
+def cmd_add_ticket(args):
+    db.add_ticket(
+        client_id=args.client_id,
+        state=args.state,
+        employee=args.employee,
+        date=args.date or datetime.now().strftime('%Y-%m-%d'),
+        contact_name=args.contact_name,
+        issue=args.issue,
+        note=args.note,
+        via=args.via,
+        additional_notes=args.additional_notes
+    )
+    print("Ticket added")
+
+
+def cmd_list_tickets(args):
+    rows = db.list_open_tickets()
+    for r in rows:
+        print(r)
+
+
+parser = argparse.ArgumentParser(description='Simple CRM CLI')
+subparsers = parser.add_subparsers(dest='command')
+
+p_init = subparsers.add_parser('init')
+p_init.set_defaults(func=cmd_init)
+
+p_add_client = subparsers.add_parser('add_client')
+p_add_client.add_argument('--origin')
+p_add_client.add_argument('--status')
+p_add_client.add_argument('--reason_baja')
+p_add_client.add_argument('--full_name')
+p_add_client.add_argument('--dni_nie')
+p_add_client.add_argument('--emails')
+p_add_client.add_argument('--province')
+p_add_client.add_argument('--city')
+p_add_client.add_argument('--address')
+p_add_client.add_argument('--postal_code')
+p_add_client.add_argument('--legal_form')
+p_add_client.add_argument('--company_name')
+p_add_client.add_argument('--commercial_name')
+p_add_client.add_argument('--nif')
+p_add_client.add_argument('--phones')
+p_add_client.set_defaults(func=cmd_add_client)
+
+p_list_clients = subparsers.add_parser('list_clients')
+p_list_clients.set_defaults(func=cmd_list_clients)
+
+p_search = subparsers.add_parser('search')
+p_search.add_argument('--name')
+p_search.add_argument('--company')
+p_search.add_argument('--domain')
+p_search.set_defaults(func=cmd_search)
+
+p_add_domain = subparsers.add_parser('add_domain')
+p_add_domain.add_argument('client_id', type=int)
+p_add_domain.add_argument('domain_name')
+p_add_domain.add_argument('--date_added')
+p_add_domain.add_argument('--type')
+p_add_domain.add_argument('--migration_status')
+p_add_domain.add_argument('--migration_date')
+p_add_domain.add_argument('--server_user')
+p_add_domain.add_argument('--server_password')
+p_add_domain.add_argument('--domain_server')
+p_add_domain.add_argument('--notes')
+p_add_domain.set_defaults(func=cmd_add_domain)
+
+p_add_ticket = subparsers.add_parser('add_ticket')
+p_add_ticket.add_argument('client_id', type=int)
+p_add_ticket.add_argument('--state')
+p_add_ticket.add_argument('--employee')
+p_add_ticket.add_argument('--date')
+p_add_ticket.add_argument('--contact_name')
+p_add_ticket.add_argument('--issue')
+p_add_ticket.add_argument('--note')
+p_add_ticket.add_argument('--via')
+p_add_ticket.add_argument('--additional_notes')
+p_add_ticket.set_defaults(func=cmd_add_ticket)
+
+p_list_tickets = subparsers.add_parser('list_tickets')
+p_list_tickets.set_defaults(func=cmd_list_tickets)
+
+
+def main():
+    args = parser.parse_args()
+    if hasattr(args, 'func'):
+        args.func(args)
+    else:
+        parser.print_help()
+
+
+if __name__ == '__main__':
+    main()

--- a/crm_app/database.py
+++ b/crm_app/database.py
@@ -1,0 +1,172 @@
+import sqlite3
+import json
+from pathlib import Path
+
+DB_PATH = Path(__file__).resolve().parent / 'crm.db'
+
+def get_connection():
+    return sqlite3.connect(DB_PATH)
+
+def init_db():
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('''CREATE TABLE IF NOT EXISTS clients (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        origin TEXT,
+        status TEXT,
+        reason_baja TEXT,
+        full_name TEXT,
+        dni_nie TEXT,
+        emails TEXT,
+        province TEXT,
+        city TEXT,
+        address TEXT,
+        postal_code TEXT,
+        legal_form TEXT,
+        company_name TEXT,
+        commercial_name TEXT,
+        nif TEXT,
+        phones TEXT
+    )''')
+    c.execute('''CREATE TABLE IF NOT EXISTS domains (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        client_id INTEGER,
+        domain_name TEXT,
+        date_added TEXT,
+        type TEXT,
+        migration_status TEXT,
+        migration_date TEXT,
+        server_user TEXT,
+        server_password TEXT,
+        domain_server TEXT,
+        notes TEXT,
+        FOREIGN KEY(client_id) REFERENCES clients(id)
+    )''')
+    c.execute('''CREATE TABLE IF NOT EXISTS tickets (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        client_id INTEGER,
+        state TEXT,
+        employee TEXT,
+        date TEXT,
+        contact_name TEXT,
+        issue TEXT,
+        note TEXT,
+        via TEXT,
+        additional_notes TEXT,
+        FOREIGN KEY(client_id) REFERENCES clients(id)
+    )''')
+    conn.commit()
+    conn.close()
+
+
+def add_client(**kwargs):
+    conn = get_connection()
+    c = conn.cursor()
+    emails = json.dumps(kwargs.get('emails', []))
+    phones = json.dumps(kwargs.get('phones', []))
+    c.execute('''INSERT INTO clients (origin, status, reason_baja, full_name, dni_nie, emails,
+        province, city, address, postal_code, legal_form, company_name, commercial_name,
+        nif, phones) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''', (
+        kwargs.get('origin'),
+        kwargs.get('status'),
+        kwargs.get('reason_baja'),
+        kwargs.get('full_name'),
+        kwargs.get('dni_nie'),
+        emails,
+        kwargs.get('province'),
+        kwargs.get('city'),
+        kwargs.get('address'),
+        kwargs.get('postal_code'),
+        kwargs.get('legal_form'),
+        kwargs.get('company_name'),
+        kwargs.get('commercial_name'),
+        kwargs.get('nif'),
+        phones
+    ))
+    conn.commit()
+    conn.close()
+
+
+def list_clients():
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('SELECT id, full_name, company_name FROM clients')
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def add_domain(client_id, domain_name, **kwargs):
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('''INSERT INTO domains (client_id, domain_name, date_added, type, migration_status,
+        migration_date, server_user, server_password, domain_server, notes)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)''', (
+        client_id,
+        domain_name,
+        kwargs.get('date_added'),
+        kwargs.get('type'),
+        kwargs.get('migration_status'),
+        kwargs.get('migration_date'),
+        kwargs.get('server_user'),
+        kwargs.get('server_password'),
+        kwargs.get('domain_server'),
+        kwargs.get('notes')
+    ))
+    conn.commit()
+    conn.close()
+
+
+def add_ticket(client_id, **kwargs):
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute('''INSERT INTO tickets (client_id, state, employee, date, contact_name,
+        issue, note, via, additional_notes) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)''', (
+        client_id,
+        kwargs.get('state'),
+        kwargs.get('employee'),
+        kwargs.get('date'),
+        kwargs.get('contact_name'),
+        kwargs.get('issue'),
+        kwargs.get('note'),
+        kwargs.get('via'),
+        kwargs.get('additional_notes')
+    ))
+    conn.commit()
+    conn.close()
+
+
+def list_open_tickets():
+    conn = get_connection()
+    c = conn.cursor()
+    c.execute("SELECT id, client_id, state, note FROM tickets WHERE state != 'Finalizado'")
+    rows = c.fetchall()
+    conn.close()
+    return rows
+
+
+def search_clients(name=None, company=None, domain=None):
+    conn = get_connection()
+    c = conn.cursor()
+    query = "SELECT DISTINCT clients.id, full_name, company_name FROM clients"
+    joins = []
+    conditions = []
+    params = []
+    if domain:
+        joins.append("JOIN domains ON domains.client_id = clients.id")
+        conditions.append("domains.domain_name LIKE ?")
+        params.append(f"%{domain}%")
+    if name:
+        conditions.append("full_name LIKE ?")
+        params.append(f"%{name}%")
+    if company:
+        conditions.append("company_name LIKE ?")
+        params.append(f"%{company}%")
+    if joins:
+        query += " " + " ".join(joins)
+    if conditions:
+        query += " WHERE " + " AND ".join(conditions)
+    c.execute(query, params)
+    rows = c.fetchall()
+    conn.close()
+    return rows


### PR DESCRIPTION
## Summary
- add a simple SQLite backed CLI for managing clients, domains and tickets
- document basic usage
- ignore generated files

## Testing
- `python -m crm_app init`
- `python -m crm_app add_client --full_name "Juan Perez" --company_name "Mi Empresa" --emails juan@example.com --phones 123456 --origin App --status Activo`
- `python -m crm_app list_clients`
- `python -m crm_app add_domain 1 example.com --type comprado --domain_server APP`
- `python -m crm_app add_ticket 1 --state "En proceso" --employee "Ana" --contact_name "Juan" --issue "example.com" --note "Error correo" --via Telefono`
- `python -m crm_app list_tickets`
- `python -m crm_app search --domain example.com`
- `python -m crm_app --help | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68820f68bd44832ca95333e273a1536a